### PR TITLE
updated user association

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,3 @@
 class Role < ApplicationRecord
-    has_many :users
+    has_many :users 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  belongs_to :role
+  belongs_to :role, optional: true
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -41,6 +41,7 @@
   <div class="actions">
     <%= f.submit "Sign up" %>
   </div>
+  <%= render "devise/shared/links" %>
 <% end %>
 
-<%= render "devise/shared/links" %>
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,11 +34,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_14_002902) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.bigint "role_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["role_id"], name: "index_users_on_role_id"
   end
 
+  add_foreign_key "users", "roles"
 end


### PR DESCRIPTION
- added "optional: true" next to the user association. This is basically telling Rails that it is not necessary for a User record to have an associated Role record upon creation. 